### PR TITLE
Update hab Ollama model list to verified real tags

### DIFF
--- a/proxy_server_config.railway.yaml
+++ b/proxy_server_config.railway.yaml
@@ -1,18 +1,39 @@
 model_list:
-  # Ollama models via hab (Tailscale)
-  - model_name: llama3
+  # Ollama models on hab (Tailscale) - tags verified present on the node
+  - model_name: llama3.1:8b
     litellm_params:
       model: ollama/llama3.1:8b
       api_base: http://100.75.148.4:11434  # hab via Tailscale
     model_info:
-      id: "hab-llama3"
+      id: "hab-llama3.1-8b"
 
-  - model_name: llama3.1
+  - model_name: qwen3.5
     litellm_params:
-      model: ollama/llama3.1:8b
+      model: ollama/qwen3.5:latest
       api_base: http://100.75.148.4:11434  # hab via Tailscale
     model_info:
-      id: "hab-llama3.1"
+      id: "hab-qwen3.5"
+
+  - model_name: glm-4.7-flash
+    litellm_params:
+      model: ollama/glm-4.7-flash:latest
+      api_base: http://100.75.148.4:11434  # hab via Tailscale
+    model_info:
+      id: "hab-glm-4.7-flash"
+
+  - model_name: glm4
+    litellm_params:
+      model: ollama/glm4:latest
+      api_base: http://100.75.148.4:11434  # hab via Tailscale
+    model_info:
+      id: "hab-glm4"
+
+  - model_name: gpt-oss:20b
+    litellm_params:
+      model: ollama/gpt-oss:20b
+      api_base: http://100.75.148.4:11434  # hab via Tailscale
+    model_info:
+      id: "hab-gpt-oss-20b"
 
   - model_name: gemma3
     litellm_params:
@@ -21,12 +42,12 @@ model_list:
     model_info:
       id: "hab-gemma3"
 
-  - model_name: glm4
+  - model_name: internvl3.5:8b
     litellm_params:
-      model: ollama/glm4:latest
+      model: ollama/blaifa/InternVL3_5:8b
       api_base: http://100.75.148.4:11434  # hab via Tailscale
     model_info:
-      id: "hab-glm4"
+      id: "hab-internvl3.5-8b"
 
   # Wildcard support for any Ollama model on hab
   - model_name: "ollama/*"


### PR DESCRIPTION
## Summary
Focused, single-file update to the hab Ollama config in `proxy_server_config.railway.yaml`. Replaces the stale placeholder model names with the **actual model tags hosted on hab** (`100.75.148.4`).

This is intentionally scoped to hab only - no hugo / proxychains / LiteLLM-upgrade changes are included (those live in the larger `upgrade-litellm-v1.80.7` branch / PR #4).

## Changes
`main` previously exposed placeholder names (`llama3`, `llama3.1`) and only 4 models. Updated to the real, verified tags:

| model_name | ollama model |
|---|---|
| `llama3.1:8b` | `ollama/llama3.1:8b` |
| `qwen3.5` | `ollama/qwen3.5:latest` |
| `glm-4.7-flash` | `ollama/glm-4.7-flash:latest` |
| `glm4` | `ollama/glm4:latest` |
| `gpt-oss:20b` | `ollama/gpt-oss:20b` |
| `gemma3` | `ollama/gemma3:latest` |
| `internvl3.5:8b` | `ollama/blaifa/InternVL3_5:8b` |

The `ollama/*` wildcard and all existing settings (`aiohttp_trust_env: True`, `store_model_in_db: False`, etc.) are unchanged.

## Testing
- Tags confirmed against hab's live `/api/tags`.
- Live `/api/chat` completions verified on hab for `gemma3`, `llama3.1:8b`, and `qwen3.5` (all returned expected output) over Tailscale.
- YAML validated (8 model entries).

## Diff
Single file, +30 / -9.